### PR TITLE
Fix unknown segment in iOS 18.0 builds

### DIFF
--- a/sep-fw-dyld-cache-loader.py
+++ b/sep-fw-dyld-cache-loader.py
@@ -395,6 +395,7 @@ def LoadLiefObjToIDA(li, fileOffset, liefObj, baseAddr, binName, sepFwData, shar
                  (sectSegName == "__LEGION") or \
                  (sectSegName == "__DATA_CONST") or \
                  (sectSegName == "__BOOTARGS") or \
+                 (sectSegName == "__SEPOS") or \
                  (sectSegName == "STACK"):
                 if True:
                     dataOffset = sepFwData.find(section.content)
@@ -405,7 +406,7 @@ def LoadLiefObjToIDA(li, fileOffset, liefObj, baseAddr, binName, sepFwData, shar
                     # ida_bytes.put_bytes(eaBeginAddr, section.content.tobytes())
                     idaapi.mem2base(section.content.tobytes(), eaBeginAddr, -1)
             else:
-                RaiseException("[-] unkown segment: %s" % (sectSegName))
+                RaiseException("[-] unknown segment: %s" % (sectSegName))
 
         # format '__mod_init_func'
         if section.name == "__mod_init_func":


### PR DESCRIPTION
With iOS 18 when I open a decrypted SEP, I have this error:

![image](https://github.com/user-attachments/assets/69e2bd88-9e3f-4db7-8007-63aec04d9851)

I added the `__SEPOS` segment in the elif statement, this seems to fix the issue.

